### PR TITLE
Fix error logging

### DIFF
--- a/feedback.js
+++ b/feedback.js
@@ -41,7 +41,7 @@ function undoButtonAnimation() {
 }
 
 function handleError(error) {
-    console.log('Error: ${error}');
+    console.log(`Error: ${error}`);
 }
 
 function notifyBackgroundPage() {


### PR DESCRIPTION
Template strings require backticks (`) instead of quotes.